### PR TITLE
fix: Handle non-string values when generating ID from record properties

### DIFF
--- a/target_chromadb/sinks.py
+++ b/target_chromadb/sinks.py
@@ -74,7 +74,7 @@ class ChromaSink(BatchSink):
                 record[self.document_text_property].encode("utf-8")
             ).hexdigest()
         else:
-            id = ":".join([record[key] for key in self.key_properties])
+            id = ":".join([str(record[key]) for key in self.key_properties])
 
         self.collection.add(
             embeddings=[record[self.embeddings_property]],


### PR DESCRIPTION
```
TypeError: sequence item 1: expected str instance, int found
```

When using record properties to generate an ID, cast all values to `str` first.